### PR TITLE
Fix gke_deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,9 @@ gke_docker_push: build
 	docker tag $(IMAGE_NAME):$(IMAGE_TAG) $(IMAGE):$(CIRCLE_SHA1)
 	docker push $(IMAGE)
 
-
-_helm:
-	curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash -s -- -v v2.11.0
-
-gke_deploy: _helm
+gke_deploy:
 	gcloud --quiet container clusters get-credentials $(GKE_CLUSTER_NAME) $(CLUSTER_ZONE_REGION)
 	#helm \
 	#	--set "global.env=$(HELM_ENV)" \
 	#	--set "IMAGE.$(HELM_ENV)=$(IMAGE):$(CIRCLE_SHA1)" \
-	#	upgrade --install platformmonitoringapi deploy/platformmonitoringapi/ --wait --timeout 600
+	#	upgrade --install platformmonitoring deploy/platformmonitoring/ --wait --timeout 600


### PR DESCRIPTION
Deployments fail since May 29, 2019, last failure: https://circleci.com/gh/neuromation/platform-monitoring/468.

Supposed reason: pip-extra-index was not passed correctly to the container: 
https://github.com/neuromation/platform-monitoring/blob/2bc2b53b66bbfce80caf446089fb1c48fa5cc246/Makefile#L6