### PR TITLE
Suppress Elasticsearch's ScanError

### DIFF
--- a/platform_monitoring/logs.py
+++ b/platform_monitoring/logs.py
@@ -159,6 +159,7 @@ class ElasticsearchLogReader(LogReader):
             # words, our client code has up to 1 minute to process previous
             # results and fetch next ones.
             scroll="1m",
+            raise_on_error=False,
             query=query,
             preserve_order=True,
             size=100,


### PR DESCRIPTION
Suppress elasticsearch's `ScanError: Scroll request has only succeeded on 149 shards out of 150.` https://github.com/neuromation/platform-monitoring/issues/43

According to the code, the setting `self.raise_on_error` will affect only raising `ScanError` here: https://github.com/aio-libs/aioelasticsearch/blob/3e766c7ce8eb6f5bc8e1505d24e3413472f37485/aioelasticsearch/helpers.py#L75-L78