### PR TITLE
fix double run for test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,7 @@ workflows:
               ignore:
                 - master
                 - /release.*/
+                - /artifactory.*/
                  
   dev:
     jobs:


### PR DESCRIPTION
we have this test job that runs twice when branch is master or release
now, we set it to run only once for these branches