### PR TITLE
Adapt `JobsService` to send chunks of docker-save response

### DIFF
--- a/platform_monitoring/api.py
+++ b/platform_monitoring/api.py
@@ -228,7 +228,8 @@ class MonitoringApiHandler:
 
         container = await self._parse_save_container(request)
         try:
-            await self._jobs_service.save(job, user, container)
+            async for chunk in self._jobs_service.save(job, user, container):
+                pass
         except JobException as exc:
             return json_response(
                 {"error": str(exc)}, status=HTTPInternalServerError.status_code
@@ -368,7 +369,9 @@ async def create_app(config: Config) -> aiohttp.web.Application:
             app["monitoring_app"]["log_reader_factory"] = log_reader_factory
 
             app["monitoring_app"]["jobs_service"] = JobsService(
-                jobs_client=platform_client.jobs, kube_client=kube_client
+                jobs_client=platform_client.jobs,
+                kube_client=kube_client,
+                docker_config=config.docker,
             )
 
             yield

--- a/platform_monitoring/config.py
+++ b/platform_monitoring/config.py
@@ -61,10 +61,16 @@ class RegistryConfig:
 
 
 @dataclass(frozen=True)
+class DockerConfig:
+    docker_engine_api_port: int = 2375
+
+
+@dataclass(frozen=True)
 class Config:
     server: ServerConfig
     platform_api: PlatformApiConfig
     platform_auth: PlatformAuthConfig
     elasticsearch: ElasticsearchConfig
     kube: KubeConfig
+    docker: DockerConfig
     registry: RegistryConfig

--- a/platform_monitoring/config_factory.py
+++ b/platform_monitoring/config_factory.py
@@ -7,6 +7,7 @@ from yarl import URL
 
 from .config import (
     Config,
+    DockerConfig,
     ElasticsearchConfig,
     KubeClientAuthType,
     KubeConfig,
@@ -32,6 +33,7 @@ class EnvironConfigFactory:
             elasticsearch=self._create_elasticsearch(),
             kube=self._create_kube(),
             registry=self._create_registry(),
+            docker=self._create_docker(),
         )
 
     def _create_server(self) -> ServerConfig:
@@ -90,3 +92,6 @@ class EnvironConfigFactory:
 
     def _create_registry(self) -> RegistryConfig:
         return RegistryConfig(url=URL(self._environ["NP_MONITORING_REGISTRY_URL"]))
+
+    def _create_docker(self) -> DockerConfig:
+        return DockerConfig()

--- a/platform_monitoring/docker_client.py
+++ b/platform_monitoring/docker_client.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 
 from aiodocker import Docker as AioDocker
-from aiodocker.exceptions import DockerError
 from aiodocker.images import DockerImages as AioDockerImages
 from docker_image.reference import (
     InvalidReference as _InvalidImageReference,
@@ -28,17 +27,6 @@ class Docker(AioDocker):
         super().__init__(*args, **kwargs)
 
         self.images = DockerImages(self)
-
-
-def check_docker_push_suceeded(
-    repo: str, tag: str, payload: List[Dict[str, Any]]
-) -> None:
-    for item in payload:
-        error = item.get("error")
-        if error:
-            raise DockerError(
-                500, dict(message=f"Failed to push image '{repo}:{tag}': {error}")
-            )
 
 
 class ImageReferenceError(ValueError):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 import pytest
 from platform_monitoring.config import (
     Config,
+    DockerConfig,
     ElasticsearchConfig,
     KubeClientAuthType,
     KubeConfig,
@@ -80,6 +81,7 @@ def test_create(cert_authority_path: str, token_path: str) -> None:
             client_conn_pool_size=333,
         ),
         registry=RegistryConfig(url=URL("http://testhost:5000")),
+        docker=DockerConfig(),
     )
 
 

--- a/tests/unit/test_docker_client.py
+++ b/tests/unit/test_docker_client.py
@@ -1,32 +1,5 @@
-from typing import Any, Dict, List
-
 import pytest
-from platform_monitoring.docker_client import (
-    DockerError,
-    ImageReference,
-    ImageReferenceError,
-    check_docker_push_suceeded,
-)
-
-
-def test_check_docker_push_succeeded() -> None:
-    payload: List[Dict[str, Any]] = [
-        {"status": "The push refers to repository [registry:80/testuser/alpine]"},
-        {
-            "errorDetail": {
-                "message": (
-                    "Get https://registry:80/v2/: dial tcp: "
-                    "lookup registry on 10.0.2.3:53: no such host"
-                )
-            },
-            "error": (
-                "Get https://registry:80/v2/: dial tcp: "
-                "lookup registry on 10.0.2.3:53: no such host"
-            ),
-        },
-    ]
-    with pytest.raises(DockerError, match="Failed to push image 'repo:tag'"):
-        check_docker_push_suceeded("repo", "tag", payload)
+from platform_monitoring.docker_client import ImageReference, ImageReferenceError
 
 
 class TestImageReference:


### PR DESCRIPTION
Regarding https://github.com/neuromation/platform-monitoring/issues/59: adapt `JobsService` to send chunks of docker-save response. 

This PR should be considered as a preparatory step for contraversial PR https://github.com/neuromation/platform-monitoring/pull/66