### PR TITLE
fix helm hook preventing platformonitoring deploy in new cluster

### DIFF
--- a/deploy/platformmonitoringapi/templates/dockerengineapi.yml
+++ b/deploy/platformmonitoringapi/templates/dockerengineapi.yml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: dockerengineapi
   annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade,replace"
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
   nginx.conf: |-
     user root root;


### PR DESCRIPTION
Currently deploy of platformmonitoring in new cluster is failing because of `replace` helm hook: `dockerengineapi` configmap is not installing and daemonsets cannot start. I didn't find in docs any description of this helm hook, I guess it doesn't exist and helm just ignores this configmap.