### PR TITLE
Disable Docker API's nginx caching 

### DIFF
--- a/deploy/platformmonitoringapi/templates/dockerengineapi.yml
+++ b/deploy/platformmonitoringapi/templates/dockerengineapi.yml
@@ -18,6 +18,7 @@ data:
             listen 2375;
             location / {
                 proxy_pass http://unix:/var/run/docker.sock:/;
+                proxy_buffering off;
             }
         }
     }


### PR DESCRIPTION
closes https://github.com/neuromation/platform-monitoring/issues/76

The problem was that daemonset `dockerengineapi`, which uses nginx, buffered streaming responses such that responses with `Transfer-Encoding: chunked` were being received in a single HTTP response, thus the streaming neuro-save didn't make sense.