### PR TITLE
Improve API tests

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -199,7 +199,7 @@ async def infinite_job(
     await jobs_client.long_polling_by_job_id(job_id, status="running")
     yield job_id
 
-    await jobs_client.delete_job(job_id, assert_success=False)
+    await jobs_client.delete_job(job_id)
 
 
 class TestApi:


### PR DESCRIPTION
Side cleanup-like work:
1. move `await jobs_client.long_polling_by_job_id(job_id, status="running")` to `infinite_job` not to repeat it everywhere,
2. add debug message on wrong chunks for some `save` tests
3. fix unintended logic and potential flakiness in `test_save_not_running_job`: before, the test was passing because the job was in `pending` state (`infinite_job` was just created), and the killing signal sent by `await jobs_client.delete_job(infinite_job)` didn't make any change to the pod's state as we were not waiting for it. In this PR, we made this test more robust by explicitly waiting for the job to become `running`, killing it and explicitly waiting for the job to terminate.