### PR TITLE
Improve reading logs of finished jobs.

### DIFF
--- a/platform_monitoring/kube_client.py
+++ b/platform_monitoring/kube_client.py
@@ -219,21 +219,32 @@ class ContainerStatus:
     @property
     def is_waiting(self) -> bool:
         state = self._payload.get("state")
-        return not state or "waiting" in state
+        return "waiting" in state if state else True
 
     @property
     def is_running(self) -> bool:
         state = self._payload.get("state")
-        return (not not state) and "running" in state
+        return "running" in state if state else False
+
+    @property
+    def is_terminated(self) -> bool:
+        state = self._payload.get("state")
+        return "terminated" in state if state else False
 
     @property
     def can_restart(self) -> bool:
-        return self._restart_policy != "Never"
+        if self._restart_policy == "Never":
+            return False
+        if self._restart_policy == "Always":
+            return True
+        assert self._restart_policy == "OnFailure"
+        try:
+            return self._payload["state"]["terminated"]["exitCode"] != 0
+        except KeyError:
+            return True
 
     @property
-    def restart_count(self) -> Optional[int]:
-        if not self.can_restart:
-            return None
+    def restart_count(self) -> int:
         return self._payload.get("restartCount") or 0
 
     @property
@@ -248,6 +259,17 @@ class ContainerStatus:
             except KeyError:
                 # waiting
                 return None
+        return iso8601.parse_date(date_str)
+
+    @property
+    def finished_at(self) -> Optional[datetime]:
+        try:
+            date_str = self._payload["state"]["terminated"]["finishedAt"]
+            if not date_str:
+                return None
+        except KeyError:
+            # running or waiting
+            return None
         return iso8601.parse_date(date_str)
 
 
@@ -436,7 +458,7 @@ class KubeClient:
                 status = await self.get_container_status(pod_name)
                 if status.is_running:
                     return status
-                if not (status.is_waiting or status.can_restart):
+                if status.is_terminated and not status.can_restart:
                     raise JobNotFoundException
                 await asyncio.sleep(interval_s)
 

--- a/tests/integration/conftest_kube.py
+++ b/tests/integration/conftest_kube.py
@@ -99,12 +99,7 @@ class MyKubeClient(KubeClient):
             async with timeout(timeout_s):
                 while True:
                     status = await self.get_container_status(name)
-                    restart_count = status.restart_count
-                    if restart_count is None:
-                        print(f"restart_count is None!!! status = {status.__dict__}")
-                        break
-                    assert restart_count is not None
-                    if restart_count >= count:
+                    if status.restart_count >= count:
                         break
                     await asyncio.sleep(interval_s)
         except asyncio.TimeoutError:


### PR DESCRIPTION
* Read logs of just finished jobs directly from Kubernetes instead
  of reading from the archive and waiting while they be completely
  archived.
* Do not wait after successful finishing jobs with the "OnFailure"
  restart policy.