### PR TITLE
Fix filtering S3 keys

### DIFF
--- a/platform_monitoring/logs.py
+++ b/platform_monitoring/logs.py
@@ -299,7 +299,7 @@ class S3LogReader(LogReader):
 
     @trace
     async def _load_log_keys(self, since: Optional[datetime]) -> List[str]:
-        since_time_str = f"{since:%Y%m%d%H%M%S}" if since else ""
+        since_time_str = f"{since:%Y%m%d%H%M}" if since else ""
         paginator = self._s3_client.get_paginator("list_objects_v2")
         keys: List[Tuple[int, int, str]] = []
         async for page in paginator.paginate(

--- a/tests/unit/test_logs.py
+++ b/tests/unit/test_logs.py
@@ -43,23 +43,23 @@ class TestS3LogReader:
             [
                 {
                     "Contents": [
-                        {"Key": "s3-key/20210131120200_0.gz"},
-                        {"Key": "s3-key/20210131120100_1.gz"},
+                        {"Key": "s3-key/202101311202_0.gz"},
+                        {"Key": "s3-key/202101311201_1.gz"},
                     ]
                 },
-                {"Contents": [{"Key": "s3-key/20210131120100_0.gz"}]},
+                {"Contents": [{"Key": "s3-key/202101311201_0.gz"}]},
             ]
         )
 
         async with log_reader:
             assert list(await log_reader._load_log_keys(None)) == [
-                "s3-key/20210131120100_0.gz",
-                "s3-key/20210131120100_1.gz",
-                "s3-key/20210131120200_0.gz",
+                "s3-key/202101311201_0.gz",
+                "s3-key/202101311201_1.gz",
+                "s3-key/202101311202_0.gz",
             ]
-            dt = datetime(2021, 1, 31, 12, 2, 0, tzinfo=timezone.utc)
+            dt = datetime(2021, 1, 31, 12, 2, 30, tzinfo=timezone.utc)
             assert list(await log_reader._load_log_keys(dt)) == [
-                "s3-key/20210131120200_0.gz",
+                "s3-key/202101311202_0.gz",
             ]
-            dt = datetime(2021, 1, 31, 12, 2, 1, tzinfo=timezone.utc)
+            dt = datetime(2021, 1, 31, 12, 3, 0, tzinfo=timezone.utc)
             assert list(await log_reader._load_log_keys(dt)) == []


### PR DESCRIPTION
The datetime format in keys does not contain seconds.