### PR TITLE
Avoid duplications and losses when merge archive and live logs

### DIFF
--- a/platform_monitoring/kube_client.py
+++ b/platform_monitoring/kube_client.py
@@ -250,25 +250,28 @@ class ContainerStatus:
     @property
     def started_at(self) -> Optional[datetime]:
         try:
-            date_str = self._payload["state"]["running"]["startedAt"]
-        except KeyError:
-            try:
+            if self.is_running:
+                date_str = self._payload["state"]["running"]["startedAt"]
+            else:
                 date_str = self._payload["state"]["terminated"]["startedAt"]
                 if not date_str:
                     return None
-            except KeyError:
-                # waiting
-                return None
+        except KeyError:
+            # waiting
+            return None
         return parse_date(date_str)
 
     @property
     def finished_at(self) -> Optional[datetime]:
         try:
-            date_str = self._payload["state"]["terminated"]["finishedAt"]
+            if self.is_terminated:
+                date_str = self._payload["state"]["terminated"]["finishedAt"]
+            else:
+                date_str = self._payload["lastState"]["terminated"]["finishedAt"]
             if not date_str:
                 return None
         except KeyError:
-            # running or waiting
+            # first run
             return None
         return parse_date(date_str)
 


### PR DESCRIPTION
Read from archive until the time of the first logs line in running container
(or until some time passed after finishing the container).

Add optional request parameter "archive_delay".