### PR TITLE
Several fixes of logs reading.

### DIFF
--- a/platform_monitoring/kube_client.py
+++ b/platform_monitoring/kube_client.py
@@ -232,6 +232,10 @@ class ContainerStatus:
         return "terminated" in state if state else False
 
     @property
+    def is_pod_terminated(self) -> bool:
+        return self.is_terminated and not self.can_restart
+
+    @property
     def can_restart(self) -> bool:
         if self._restart_policy == "Never":
             return False

--- a/tests/integration/test_kube.py
+++ b/tests/integration/test_kube.py
@@ -154,6 +154,7 @@ class TestKubeClient:
         assert not status.is_waiting
         assert not status.is_running
         assert status.is_terminated
+        assert status.is_pod_terminated
         assert status.restart_count == 0
         assert status.started_at is not None
         assert status.finished_at is not None
@@ -202,6 +203,7 @@ class TestKubeClient:
             assert not status.is_waiting
             assert not status.is_running
             assert status.is_terminated
+            assert not status.is_pod_terminated
             assert status.restart_count == 0
             assert status.started_at is not None
             assert status.started_at == first_started_at
@@ -256,6 +258,7 @@ class TestKubeClient:
         assert not status.is_waiting
         assert not status.is_running
         assert status.is_terminated
+        assert status.is_pod_terminated
         assert status.restart_count == 0
         assert status.started_at is not None
         assert status.finished_at is not None
@@ -303,6 +306,7 @@ class TestKubeClient:
             assert not status.is_waiting
             assert not status.is_running
             assert status.is_terminated
+            assert not status.is_pod_terminated
             assert status.restart_count == 0
             assert status.started_at is not None
             assert status.started_at == first_started_at


### PR DESCRIPTION
* Read logs of recently terminated job from container instead of
  archive. It guarantees that all logs are read without long wait.

* Start reading from archive (to the first live line) even if there
  were no restarts. It eliminates possible losses if live logs
  overflowed the container buffer.