### PR TITLE
More lenient error message check in test_save_push_failure

### DIFF
--- a/tests/integration/test_jobs_service.py
+++ b/tests/integration/test_jobs_service.py
@@ -284,8 +284,8 @@ class TestJobsService:
         assert data[2]["status"] == msg
 
         assert "status" not in data[3]
-        msg = f"Get https://{registry_host}/v2/: dial tcp: lookup unknown"
-        assert msg in data[3]["error"]
+        assert f"https://{registry_host}/v2/" in data[3]["error"]
+        assert ": dial tcp: lookup unknown" in data[3]["error"]
 
     async def test_save_commit_fails_with_exception(
         self,


### PR DESCRIPTION
For some reasons, the error message in `tests/integration/test_jobs_service.py::TestJobsService::test_save_push_failure` on my computer is now `'Get "https://unknown:5000/v2/": dial tcp: lookup unknown: Temporary failure in name resolution'` instead of expected `'Get https://unknown:5000/v2/: dial tcp: lookup unknown'` (added double quotes around a URL). This PR makes the test passing in both cases, with and without quotes.