### PR TITLE
Do not fail on empty log line

### DIFF
--- a/platform_monitoring/logs.py
+++ b/platform_monitoring/logs.py
@@ -361,7 +361,7 @@ class S3LogReader(LogReader):
                             if self._debug and key:
                                 yield f"~~~ From file {basename(key)}\n".encode()
                                 key = ""
-                            log = event["log"]
+                            log = event.get("log", "")
                             yield self.encode_log(time_str, log)
                         except Exception:
                             logger.exception("Invalid log entry: %r", line)

--- a/tests/unit/test_logs.py
+++ b/tests/unit/test_logs.py
@@ -1,5 +1,6 @@
+import json
 from collections.abc import AsyncIterator, Callable, Sequence
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from typing import Any
 from unittest import mock
 
@@ -28,6 +29,27 @@ class TestS3LogReader:
             paginator.paginate.side_effect = paginate
             s3_client.get_paginator.return_value = paginator
 
+        return _setup
+
+    @pytest.fixture
+    def setup_s3_key_content(
+        self,
+        s3_client: mock.Mock,
+    ) -> Callable[[dict[str, list[str]]], None]:
+        def _setup(content: dict[str, list[str]]) -> None:
+            async def get_object(
+                Key: str, *args: Any, **kwargs: Any
+            ) -> dict[str, Any]:
+                async def _iter() -> AsyncIterator[str]:
+                    for line in content[Key]:
+                        yield line
+                body = mock.AsyncMock()
+                body.iter_lines = mock.MagicMock()
+                body.iter_lines.return_value = mock.AsyncMock()
+                body.iter_lines.return_value.__aiter__.side_effect = _iter
+                return {"ContentType": "", "Body": body}
+
+            s3_client.get_object = get_object
         return _setup
 
     @pytest.fixture
@@ -63,3 +85,31 @@ class TestS3LogReader:
             ]
             dt = datetime(2021, 1, 31, 12, 3, 0, tzinfo=timezone.utc)
             assert list(await log_reader._load_log_keys(dt)) == []
+
+    async def test_iterate_log_chunks(
+        self,
+        log_reader: S3LogReader,
+        setup_s3_pages: Callable[[Sequence[dict[str, Any]]], None],
+        setup_s3_key_content: Callable[[dict[str, Any]], None],
+    ) -> None:
+        now = datetime.now(tz=timezone.utc)
+        now_as_key = now.strftime("%Y%m%d%H%M")
+        setup_s3_pages([{"Contents": [{"Key": f"s3-key/{now_as_key}_0.gz"}]}])
+
+        log_lines = ["qwe\n", "line2", "line3", "", "\n\n\n", "something here"]
+
+        def later_iso(sec: int = 0) -> str:
+            return (now + timedelta(seconds=sec)).isoformat()
+        stored_lines = []
+        for i, line in enumerate(log_lines):
+            stored_line = {"time": later_iso(i)}
+            if line:
+                stored_line["log"] = line
+            stored_lines.append(json.dumps(stored_line))
+        setup_s3_key_content({f"s3-key/{now_as_key}_0.gz": stored_lines})
+
+        res = []
+        async with log_reader as it:
+            async for chunk in it:
+                res.append(chunk.decode()[:-1])  # -1 implies removal of \n
+        assert log_lines == res


### PR DESCRIPTION
If we have a job with empty log line, for instance (simple STR):
`n run ubuntu -- bash -c "echo; echo hi;"`

platform cannot handle its logs, since fluent-bit omits "log" in logs entry:
![image](https://github.com/neuro-inc/platform-monitoring/assets/32543098/bf1d7cf3-1e30-4027-b698-1f701f990b95)
and logs from k8s:
![image](https://github.com/neuro-inc/platform-monitoring/assets/32543098/88289903-f775-4b93-be4a-4e9e4979574f)

Corresponding error from service:
```
2023-07-05 18:41:57,671 - platform_monitoring.logs - ERROR - Invalid log entry: b'{"time":"2023-07-05T18:39:49.720424314Z","stream":"stdout","logtag":"F","kubernetes":{"pod_name":"job-b34af07f-0418-4e12-8529-906c6c284f68","namespace_name":"platform-jobs","pod_id":"f06694a3-1c4e-4bfb-93ce-60f4a5ccc9c6","labels":{"platform.neuromation.io/gpu-model":"nvidia-tesla-v100","platform.neuromation.io/job":"job-b34af07f-0418-4e12-8529-906c6c284f68","platform.neuromation.io/org":"no_org","platform.neuromation.io/preset":"gpu-small","platform.neuromation.io/user":"yevheniisemendiak"},"annotations":{"cni.projectcalico.org/containerID":"4588e23019d34ca8ae8194ab98f1eed4c2ddc3666b88c49b08836418809181fc","cni.projectcalico.org/podIP":"","cni.projectcalico.org/podIPs":""},"host":"master-1","container_name":"job-b34af07f-0418-4e12-8529-906c6c284f68","docker_id":"0a85ee521ae55eaa8dadadd396875cbbd05c58037cb0f306886acbd5f8fba03b","container_hash":"0bced47fffa3361afa981854fcabcd4577cd43cebbb808cea2b1f33a3dd7f508"}}'
Traceback (most recent call last):
  File "/root/.local/lib/python3.9/site-packages/platform_monitoring/logs.py", line 364, in _iterate
    log = event["log"]
KeyError: 'log'
2023-07-05 18:41:57,674 - asyncio - ERROR - Task exception was never retrieved
future: <Task finished name='Task-448227' coro=<_forward_bytes_iterating() done, defined at /root/.local/lib/python3.9/site-packages/platform_monitoring/api.py:492> exception=KeyError('log')>
Traceback (most recent call last):
  File "/root/.local/lib/python3.9/site-packages/platform_monitoring/api.py", line 495, in _forward_bytes_iterating
    async for chunk in it:
  File "/root/.local/lib/python3.9/site-packages/platform_monitoring/logs.py", line 441, in get_pod_log_reader
    async for chunk in it:
  File "/root/.local/lib/python3.9/site-packages/platform_monitoring/logs.py", line 364, in _iterate
    log = event["log"]
KeyError: 'log'
```

Maybe, we could configure fluent-bit properly, but I haven't found how to do it.
It also might close https://github.com/neuro-inc/platform-monitoring/issues/719