### PR TITLE
feat(external-secrets): migrate platform helm charts to external secrets

### DIFF
--- a/charts/platform-monitoring/Chart.yaml
+++ b/charts/platform-monitoring/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: platform-monitoring
 description: A Helm chart for platform-monitoring service
-version: 1.0.0
+version: 1.1.0
 appVersion: 1.0.0
 dependencies:
   - name: k8s-resources

--- a/charts/platform-monitoring/templates/externalSecret.yaml
+++ b/charts/platform-monitoring/templates/externalSecret.yaml
@@ -1,0 +1,30 @@
+{{- range .Values.externalSecrets }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .name | quote }}
+  labels: {{ include "platformAdmin.labels.standard" $ | nindent 4 }}
+    service: platform-admin
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: {{ .secretStoreName | default "default-secret-store" | quote }}
+    kind: {{ .secretStoreKind | default "ClusterSecretStore" }}
+  target:
+    name: {{ .name | quote }}
+    creationPolicy: "Owner"
+    template:
+      metadata:
+        labels: {{ include "platformAdmin.labels.standard" $ | nindent 10 }}
+          service: platform-admin
+        annotations:
+          reloader.stakater.com/match: "true"
+  data:
+    {{- range $key, $ref := .data }}
+    - secretKey: {{ $key | quote }} #target K8s secret key
+      remoteRef:
+        key: {{ $ref.key | quote }} #Remote secret mount key, e.g.. vault
+        property: {{ $ref.property | quote }} #Remote secret key, e.g.. platform-admin-dsn
+    {{- end }}
+{{- end }}

--- a/charts/platform-monitoring/values.yaml
+++ b/charts/platform-monitoring/values.yaml
@@ -42,6 +42,18 @@ service:
 
 secrets: []
 
+externalSecrets:
+  - name: platform-admin-secret
+    secretStoreName: vault-backend
+    secretStoreKind: ClusterSecretStore
+    data:
+      DATABASE_URL:
+        key: kv-v2/platform
+        property: DATABASE_URL
+      API_KEY:
+        key: kv-v2/platform
+        property: API_KEY
+
 podAnnotations: {}
 
 sentry:


### PR DESCRIPTION
This PR migrates the platform helm chart to use external secrets and bumps the chart minor version.