### PR TITLE
remove concurrent loki queries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install --user --no-cache-dir --find-links /tmp/dist platform-monitoring
     && rm -rf /tmp/dist
 
 FROM python:${PY_VERSION}-slim-bookworm AS runtime
-LABEL org.opencontainers.image.source = "https://github.com/neuro-inc/platform-monitoring"
+LABEL org.opencontainers.image.source="https://github.com/neuro-inc/platform-monitoring"
 
 # Name of your service (folder under /home)
 ARG SERVICE_NAME="/platform-monitoring-api"

--- a/platform_monitoring/loki_client.py
+++ b/platform_monitoring/loki_client.py
@@ -11,6 +11,10 @@ from yarl import URL
 logger = logging.getLogger(__name__)
 
 
+class LokiClientError(Exception):
+    pass
+
+
 class LokiClient:
     def __init__(
         self,
@@ -38,18 +42,19 @@ class LokiClient:
             connect=self._conn_timeout_s, total=self._read_timeout_s
         )
 
-        async def custom_check(response: aiohttp.ClientResponse) -> None | NoReturn:
-            if not 200 <= response.status < 300:
+        async def _raise_for_status(
+            response: aiohttp.ClientResponse,
+        ) -> None:
+            if response.status >= 300:
                 text = await response.text()
                 exc_text = f"Loki response status is not 2xx. Response: {text}"
-                raise Exception(exc_text)
-            return None
+                raise LokiClientError(exc_text)
 
         self._session = aiohttp.ClientSession(
             connector=connector,
             timeout=timeout,
             trace_configs=self._trace_configs,
-            raise_for_status=custom_check,
+            raise_for_status=_raise_for_status,
         )
 
     async def close(self) -> None:

--- a/platform_monitoring/loki_client.py
+++ b/platform_monitoring/loki_client.py
@@ -45,9 +45,9 @@ class LokiClient:
         async def _raise_for_status(
             response: aiohttp.ClientResponse,
         ) -> None:
-            if response.status >= 300:
+            if not response.ok:
                 text = await response.text()
-                exc_text = f"Loki response status is not 2xx. Response: {text}"
+                exc_text = f"Loki client error. Status: {response.status}. Body: {text}"
                 raise LokiClientError(exc_text)
 
         self._session = aiohttp.ClientSession(


### PR DESCRIPTION
We don't need to run loki queries concurrently. This is already implemented on the Loki side in query frontend.