### PR TITLE
Switch platform services to seaweedfs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -667,6 +667,11 @@ python-versions = ">=3.8"
 groups = ["main"]
 markers = "platform_python_implementation != \"CPython\""
 files = [
+    {file = "brotlicffi-1.2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b13fb476a96f02e477a506423cb5e7bc21e0e3ac4c060c20ba31c44056e38c68"},
+    {file = "brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17db36fb581f7b951635cd6849553a95c6f2f53c1a707817d06eae5aeff5f6af"},
+    {file = "brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40190192790489a7b054312163d0ce82b07d1b6e706251036898ce1684ef12e9"},
+    {file = "brotlicffi-1.2.0.0-cp314-cp314t-win32.whl", hash = "sha256:a8079e8ecc32ecef728036a1d9b7105991ce6a5385cf51ee8c02297c90fb08c2"},
+    {file = "brotlicffi-1.2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ca90c4266704ca0a94de8f101b4ec029624273380574e4cf19301acfa46c61a0"},
     {file = "brotlicffi-1.2.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:9458d08a7ccde8e3c0afedbf2c70a8263227a68dea5ab13590593f4c0a4fd5f4"},
     {file = "brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:84e3d0020cf1bd8b8131f4a07819edee9f283721566fe044a20ec792ca8fd8b7"},
     {file = "brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33cfb408d0cff64cd50bef268c0fed397c46fbb53944aa37264148614a62e990"},

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -175,11 +175,11 @@ async def platform_monitoring_api_address(in_minikube: bool) -> "ApiAddress":  #
 
 @pytest.fixture(scope="session")
 def s3_config() -> S3Config:
-    s3_url = get_service_url(service_name="minio")
+    s3_url = get_service_url(service_name="seaweedfs-s3", namespace="platform")
     return S3Config(
-        region="minio",
-        access_key_id="access_key",
-        secret_access_key="secret_key",
+        region="us-east-1",
+        access_key_id="admin_access_key_id",
+        secret_access_key="admin_secret_access_key",
         endpoint_url=URL(s3_url),
         job_logs_bucket_name="logs",
     )

--- a/tests/k8s/loki-values.yml
+++ b/tests/k8s/loki-values.yml
@@ -12,11 +12,11 @@ loki:
       s3:
         bucketnames: logs
         insecure: false
-        region: minio
-        access_key_id: access_key
-        endpoint: http://minio:9000
+        region: us-east-1
+        access_key_id: admin_access_key_id
+        endpoint: http://seaweedfs-s3.platform.svc.cluster.local:9000
         s3forcepathstyle: true
-        secret_access_key: secret_key
+        secret_access_key: admin_secret_access_key
 
   schemaConfig:
     configs:
@@ -38,10 +38,10 @@ loki:
   storage_config:
     aws:
       bucketnames: logs
-      endpoint: http://minio:9000
-      region: minio
-      access_key_id: access_key
-      secret_access_key: secret_key
+      endpoint: http://seaweedfs-s3.platform.svc.cluster.local:9000
+      region: us-east-1
+      access_key_id: admin_access_key_id
+      secret_access_key: admin_secret_access_key
       insecure: false
       s3forcepathstyle: true
 

--- a/tests/k8s/platformmonitoring.yml
+++ b/tests/k8s/platformmonitoring.yml
@@ -47,13 +47,13 @@ spec:
         - name: NP_MONITORING_LOKI_ENDPOINT_URL
           value: http://loki-gateway.default.svc.cluster.local
         - name: NP_MONITORING_S3_ACCESS_KEY_ID
-          value: access_key
+          value: admin_access_key_id
         - name: NP_MONITORING_S3_SECRET_ACCESS_KEY
-          value: secret_key
+          value: admin_secret_access_key
         - name: NP_MONITORING_S3_REGION
-          value: minio
+          value: us-east-1
         - name: NP_MONITORING_S3_ENDPOINT_URL
-          value: http://minio:9000
+          value: http://seaweedfs-s3.platform.svc.cluster.local:9000
         - name: NP_MONITORING_S3_JOB_LOGS_BUCKET_NAME
           value: logs
         - name: NP_MONITORING_K8S_API_URL

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -141,12 +141,16 @@ def test_create_with_s3__default(environ: dict[str, Any]) -> None:
         job_logs_bucket_name="logs",
     )
 
-    environ["NP_MONITORING_S3_ENDPOINT_URL"] = "http://minio:9000"
+    environ["NP_MONITORING_S3_ENDPOINT_URL"] = (
+        "http://seaweedfs-s3.platform.svc.cluster.local:9000"
+    )
 
     config = EnvironConfigFactory(environ).create()
 
     assert config.s3
-    assert config.s3.endpoint_url == URL("http://minio:9000")
+    assert config.s3.endpoint_url == URL(
+        "http://seaweedfs-s3.platform.svc.cluster.local:9000"
+    )
 
 
 def test_create_with_s3(environ: dict[str, Any]) -> None:
@@ -164,12 +168,16 @@ def test_create_with_s3(environ: dict[str, Any]) -> None:
         job_logs_bucket_name="logs",
     )
 
-    environ["NP_MONITORING_S3_ENDPOINT_URL"] = "http://minio:9000"
+    environ["NP_MONITORING_S3_ENDPOINT_URL"] = (
+        "http://seaweedfs-s3.platform.svc.cluster.local:9000"
+    )
 
     config = EnvironConfigFactory(environ).create()
 
     assert config.s3
-    assert config.s3.endpoint_url == URL("http://minio:9000")
+    assert config.s3.endpoint_url == URL(
+        "http://seaweedfs-s3.platform.svc.cluster.local:9000"
+    )
 
 
 def test_create_with_logs_compact(environ: dict[str, Any]) -> None:


### PR DESCRIPTION
This pull request updates the configuration for S3-compatible storage used in platform monitoring, switching from MinIO to SeaweedFS S3, and updates all relevant credentials, endpoints, and regions across integration tests, unit tests, and Kubernetes manifests. These changes ensure consistency and correct connectivity for log storage in the new environment.

**S3 Storage Provider Migration and Configuration Updates**

*Switchover from MinIO to SeaweedFS S3:*
- Changed all S3 endpoint URLs from `http://minio:9000` to `http://seaweedfs-s3.platform.svc.cluster.local:9000` in integration test fixtures, Kubernetes manifests, and unit tests.