### PR TITLE
IT-126: bump apolo-kube-client to 25.12.2 + drop removed KubeConfig namespace kwarg

### DIFF
--- a/platform_monitoring/api.py
+++ b/platform_monitoring/api.py
@@ -1105,7 +1105,6 @@ async def create_app(config: Config) -> aiohttp.web.Application:
                 auth_cert_key_path=config.kube.auth_cert_key_path,
                 token=config.kube.token,
                 token_path=config.kube.token_path,
-                namespace=config.kube.namespace,
                 client_conn_timeout_s=config.kube.client_conn_timeout_s,
                 client_read_timeout_s=config.kube.client_read_timeout_s,
                 client_conn_pool_size=config.kube.client_conn_pool_size,

--- a/platform_monitoring/kube_client.py
+++ b/platform_monitoring/kube_client.py
@@ -406,7 +406,7 @@ class ContainerStatus:
             (last_state, "last_state"),
         ):
             state_attr = getattr(payload, state_attr_name)
-            if state_attr.running.started_at:
+            if state_attr.running and state_attr.running.started_at:
                 prop["running"] = {
                     "startedAt": format_date(state_attr.running.started_at)
                 }
@@ -421,7 +421,9 @@ class ContainerStatus:
                         state_attr.terminated.finished_at
                     )
                 prop["terminated"] = terminated
-            if state_attr.waiting.message or state_attr.waiting.reason:
+            if state_attr.waiting and (
+                state_attr.waiting.message or state_attr.waiting.reason
+            ):
                 prop["waiting"] = True
         return cls(
             name=payload.name,

--- a/platform_monitoring/log_compact.py
+++ b/platform_monitoring/log_compact.py
@@ -41,7 +41,6 @@ class App:
                 auth_cert_key_path=config.kube.auth_cert_key_path,
                 token=config.kube.token,
                 token_path=config.kube.token_path,
-                namespace=config.kube.namespace,
                 client_conn_timeout_s=config.kube.client_conn_timeout_s,
                 client_read_timeout_s=config.kube.client_read_timeout_s,
                 client_conn_pool_size=config.kube.client_conn_pool_size,

--- a/poetry.lock
+++ b/poetry.lock
@@ -315,14 +315,14 @@ pydantic = ">=2.11.7,<3.0.0"
 
 [[package]]
 name = "apolo-kube-client"
-version = "25.11.9"
+version = "25.12.2"
 description = "Apolo internal client for kubernetes API"
 optional = false
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 files = [
-    {file = "apolo_kube_client-25.11.9-py3-none-any.whl", hash = "sha256:8ee4065ac64ec6a94c9c1f3129dcea44a303e20c7df0de691f02023919d28123"},
-    {file = "apolo_kube_client-25.11.9.tar.gz", hash = "sha256:7772e7c03116b49dda6aed9a9a64522db739546154d0b4325286a5b5b9ac7aab"},
+    {file = "apolo_kube_client-25.12.2-py3-none-any.whl", hash = "sha256:a8a852b2f04051851c1e83cbe275213b26e784401a3a59c113bfe8384e4fe484"},
+    {file = "apolo_kube_client-25.12.2.tar.gz", hash = "sha256:4c11bbc4d87e26d7972c74a3e9cc3ecfbd99d3dd4cfd8eec4e7855cc9de6a5f5"},
 ]
 
 [package.dependencies]
@@ -3410,4 +3410,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "75a8a62d7811768d21eb89dce70b595f2cff5fafdae1a2bb831c7e7c6bd49192"
+content-hash = "ac27b80994708aa054fec1df58fb1ced376f40bc84c369b6f5c969392acafa9a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "trafaret==2.1.1",
     "uvloop==0.21.0",
     "apolo-apps-client==25.8.1",
-    "apolo-kube-client (>=25.11.4,<26.0.0)",
+    "apolo-kube-client (>=25.12.2,<26.0.0)",
     "tenacity (>=9.1.2,<10.0.0)",
 ]
 


### PR DESCRIPTION
Bumps apolo-kube-client to **25.12.2** (pyproject + lock) **and adapts to the KubeConfig API change**.

25.12.2 fixes the per-project egress NetworkPolicy (ingress-gateway `namespaceSelector` was dropped on serialization). It also **removed `namespace` from the Apolo `KubeConfig`** — per-project namespaces are resolved via `KubeClientSelector` (already used here). So this PR stops passing `namespace=` when constructing the Apolo `KubeConfig` for the selector (api.py, log_compact.py). The service’s own `config.KubeConfig` keeps its `namespace` field (still feeds `kube_namespace_name` for S3 log metadata), so behaviour is unchanged.

Paired with cloud-infra #491 (traefik ingress-gateway label). Ref: IT-126.